### PR TITLE
Allow reconnections and multiple controller instances

### DIFF
--- a/jellyfishlightspy/jellyfishmain.py
+++ b/jellyfishlightspy/jellyfishmain.py
@@ -113,6 +113,7 @@ class JellyFishController:
     def disconnect(self):
         try:
             self.__ws.close()
+            self.__ws = websocket.WebSocket()
         except:
             raise BaseException("Error encountered while disconnecting from controller at " + self.__address)
 

--- a/jellyfishlightspy/jellyfishmain.py
+++ b/jellyfishlightspy/jellyfishmain.py
@@ -42,13 +42,11 @@ class PatternName:
 #TODO: add a way to get the current pattern (runPattern)
 #TODO: add use of prebuilt pattern types
 class JellyFishController:
-    zones: Dict = {}
-    patternFiles: List[PatternName] = []
-    __ws = websocket.WebSocket()
-    __address: str
-    __printJSON: bool
 
     def __init__(self, address: str, printJSON: bool = False):
+        self.zones: Dict = {}
+        self.patternFiles: List[PatternName] = []
+        self.__ws = websocket.WebSocket()
         self.__address = address
         self.__printJSON = printJSON
     


### PR DESCRIPTION
Two small but important fixes:

1. Remove class attributes in favor of instance attributes. This allows each instance of the controller class to have their own websocket object, for example, instead of sharing one (which can lead to read conflicts)
2. Recreate the websocket object after disconnect to allow reconnections (websockets that have been disconnected can/should not be reused) 