### PR TITLE
Queue option to manage message reads from websocket

### DIFF
--- a/jellyfishlightspy/jellyfishmain.py
+++ b/jellyfishlightspy/jellyfishmain.py
@@ -80,7 +80,7 @@ class JellyFishController:
         #       This will still exist even with a timeout due to variable network latency
         try:
             while True:
-                self.__messageQueue.get(timeout=1)
+                self.__messageQueue.get(timeout=.1)
         except queue.Empty:
             pass
     

--- a/jellyfishlightspy/jellyfishmain.py
+++ b/jellyfishlightspy/jellyfishmain.py
@@ -113,6 +113,7 @@ class JellyFishController:
     def disconnect(self):
         try:
             self.__ws.close()
+            self.__ws = websocket.WebSocket()
         except:
             raise BaseException("Error encountered while disconnecting from controller at " + self.__address)
 

--- a/jellyfishlightspy/jellyfishmain.py
+++ b/jellyfishlightspy/jellyfishmain.py
@@ -42,13 +42,11 @@ class PatternName:
 #TODO: add a way to get the current pattern (runPattern)
 #TODO: add use of prebuilt pattern types
 class JellyFishController:
-    zones: Dict = {}
-    patternFiles: List[PatternName] = []
-    __ws = websocket.WebSocket()
-    __address: str
-    __printJSON: bool
 
     def __init__(self, address: str, printJSON: bool = False):
+        self.zones: Dict = {}
+        self.patternFiles: List[PatternName] = []
+        self.__ws = websocket.WebSocket()
         self.__address = address
         self.__printJSON = printJSON
     


### PR DESCRIPTION
@vinenoob here's a PR that's more food for thought than anything else. The intent is not to merge this code - you're welcome to close this.

To try to overcome the issue of having multiple responses (`recv()`) for a single request (`send()`), I implemented a queuing mechanism that continuously gathers messages from the websocket. This is what is suggested by `websocket-client`'s author in [this issue](https://github.com/websocket-client/websocket-client/issues/416) and in [the documentation](https://websocket-client.readthedocs.io/en/latest/threading.html).

The benefit of this is it allows you to read messages until there are none left, but it does create a race condition that highlights the inherently asynchronous nature of websockets. See the code comment on line 78 in the main file for more on this. It became clear to me that I could have more easily implemented a simple asyncio or threading mechanism to call `recv()` with a timeout and accomplished the same thing.

That said, I think I'm onto something here. My new thinking is that this library shouldn't try to force the API into a synchronous request-response paradigm that it's clearly not designed for, so it should instead continuously read messages from the websocket and store the latest state data (zones, patterns, and runPatterns) as it is received. Should be easy enough to implement now that I have this queue in place. Stay tuned for more.