### PR TITLE
Async data retrieval

### DIFF
--- a/jellyfishlightspy/jellyfishmain.py
+++ b/jellyfishlightspy/jellyfishmain.py
@@ -80,7 +80,7 @@ class JellyFishController:
         #       This will still exist even with a timeout due to variable network latency
         try:
             while True:
-                self.__messageQueue.get(timeout=1)
+                self.__messageQueue.get(timeout=.1)
         except queue.Empty:
             pass
     

--- a/jellyfishlightspy/jellyfishmain.py
+++ b/jellyfishlightspy/jellyfishmain.py
@@ -135,8 +135,15 @@ class JellyFishController:
         with self.__locks[ZONE_DATA]:
             return self.zones
 
-    def getRunPatterns(self, zones: List[str] = None, timeout = None) -> Dict:
-        """Returns dict of zones (key) and RunPattern objects"""
+    def getRunPattern(self, zone: str, timeout = None) -> RunPatternClass:
+        """Returns and stores the state of the specified zone"""
+        self.__requestData([RUN_PATTERN_DATA, zone])
+        self.__getRunPatternEvent(zone).wait(timeout)
+        with self.__locks[RUN_PATTERN_DATA]:
+            return self.runPatterns[zone]
+
+    def getRunPatterns(self, zones: List[str] = None, timeout = None) -> Dict[str, RunnPatternClass]:
+        """Returns and stores the state of specified zones"""
         zones = zones or list(self.zones.keys())
         for zone in zones:
             self.__requestData([RUN_PATTERN_DATA, zone])

--- a/jellyfishlightspy/jellyfishmain.py
+++ b/jellyfishlightspy/jellyfishmain.py
@@ -113,6 +113,7 @@ class JellyFishController:
     def disconnect(self):
         try:
             self.__ws.close()
+            self.__ws = websocket.WebSocket()
         except:
             raise BaseException("Error encountered while disconnecting from controller at " + self.__address)
 

--- a/jellyfishlightspy/jellyfishmain.py
+++ b/jellyfishlightspy/jellyfishmain.py
@@ -142,7 +142,7 @@ class JellyFishController:
         with self.__locks[RUN_PATTERN_DATA]:
             return self.runPatterns[zone]
 
-    def getRunPatterns(self, zones: List[str] = None, timeout = None) -> Dict[str, RunnPatternClass]:
+    def getRunPatterns(self, zones: List[str] = None, timeout = None) -> Dict[str, RunPatternClass]:
         """Returns and stores the state of specified zones"""
         zones = zones or list(self.zones.keys())
         for zone in zones:

--- a/jellyfishlightspy/jellyfishmain.py
+++ b/jellyfishlightspy/jellyfishmain.py
@@ -95,9 +95,10 @@ class JellyFishController:
             self.__triggerEvent(PATTERN_LIST_DATA)
         elif RUN_PATTERN_DATA in data:
             data = data[RUN_PATTERN_DATA]
-            zone = data["zoneName"][0]
-            self.runPatterns[zone] = RunPatternClassFromDict(data)
-            self.__triggerEvent(RUN_PATTERN_DATA, zone)
+            if len(data["zoneName"]) == 1:
+                zone = data["zoneName"][0]
+                self.runPatterns[zone] = RunPatternClassFromDict(data)
+                self.__triggerEvent(RUN_PATTERN_DATA, zone)
     
     def __send(self, message: str):
         if self.__printJSON:
@@ -124,11 +125,13 @@ class JellyFishController:
         self.__events[ZONE_DATA].wait(timeout)
         return self.zones
 
-    def getRunPattern(self, zone, timeout = None) -> RunPatternClass:
-        """Returns runPatternClass"""
-        self.__requestData([RUN_PATTERN_DATA, zone])
-        self.__getRunPatternEvent(zone).wait(timeout)
-        return self.runPatterns[zone]
+    def getRunPatterns(self, zones: List[str] = None, timeout = None) -> Dict:
+        """Returns dict of zones (key) and RunPattern objects"""
+        zones = zones or list(self.zones.keys())
+        for zone in zones:
+            self.__requestData([RUN_PATTERN_DATA, zone])
+            self.__getRunPatternEvent(zone).wait(timeout)
+        return self.runPatterns
     
     #Attempts to connect to a controller at the given address
     def connect(self):

--- a/jellyfishlightspy/jellyfishmain.py
+++ b/jellyfishlightspy/jellyfishmain.py
@@ -3,6 +3,7 @@
 
 import websocket
 import json
+import traceback
 from typing import Dict, List, Tuple
 from threading import Thread, Event, Lock
 from jellyfishlightspy.runPattern import *
@@ -72,9 +73,7 @@ class JellyFishController:
         return self.__events[RUN_PATTERN_DATA][zone]
     
     def __triggerEvent(self, dataKey, zone = None):
-        event = self.__events[dataKey]
-        if zone is not None:
-            event = event[zone]
+        event = self.__events[dataKey] if zone is None else self.__getRunPatternEvent(zone)
         event.set()
         event.clear()
     
@@ -85,28 +84,32 @@ class JellyFishController:
         self.__connected.clear()
     
     def __ws_on_message(self, ws, message):
-        if self.__printJSON:
-            print(f"Recieved: {message}")
-        data = json.loads(message)
-        if ZONE_DATA in data:
-            with self.__locks[ZONE_DATA]:
-                self.zones = data[ZONE_DATA]
-            self.__triggerEvent(ZONE_DATA)
-        elif PATTERN_LIST_DATA in data:
-            data = data[PATTERN_LIST_DATA]
-            with self.__locks[PATTERN_LIST_DATA]:
-                self.patternFiles = []
-                for patternFile in data:
-                    if patternFile["name"] != "":
-                        self.patternFiles.append(PatternName(patternFile["name"], patternFile["folders"]))
-            self.__triggerEvent(PATTERN_LIST_DATA)
-        elif RUN_PATTERN_DATA in data:
-            data = data[RUN_PATTERN_DATA]
-            if len(data["zoneName"]) == 1:
-                zone = data["zoneName"][0]
-                with self.__locks[RUN_PATTERN_DATA]:
-                    self.runPatterns[zone] = RunPatternClassFromDict(data)
-                self.__triggerEvent(RUN_PATTERN_DATA, zone)
+        try:
+            if self.__printJSON:
+                print(f"Recieved: {message}")
+            data = json.loads(message)
+            if ZONE_DATA in data:
+                with self.__locks[ZONE_DATA]:
+                    self.zones = data[ZONE_DATA]
+                self.__triggerEvent(ZONE_DATA)
+            elif PATTERN_LIST_DATA in data:
+                data = data[PATTERN_LIST_DATA]
+                with self.__locks[PATTERN_LIST_DATA]:
+                    self.patternFiles = []
+                    for patternFile in data:
+                        if patternFile["name"] != "":
+                            self.patternFiles.append(PatternName(patternFile["name"], patternFile["folders"]))
+                self.__triggerEvent(PATTERN_LIST_DATA)
+            elif RUN_PATTERN_DATA in data:
+                data = data[RUN_PATTERN_DATA]
+                if len(data["zoneName"]) == 1:
+                    zone = data["zoneName"][0]
+                    with self.__locks[RUN_PATTERN_DATA]:
+                        self.runPatterns[zone] = RunPatternClassFromDict(data)
+                    self.__triggerEvent(RUN_PATTERN_DATA, zone)
+        except:
+            print("Error encountered while processing websocket data!")
+            traceback.print_exc()
     
     def __send(self, message: str):
         if self.__printJSON:
@@ -163,16 +166,16 @@ class JellyFishController:
             self.__wsThread = Thread(target=lambda: self.__ws.run_forever(), daemon=True)
             self.__wsThread.start()
             self.__connected.wait()
-        except:
-            raise BaseException("Could not connect to controller at " + self.__address)
+        except Exception as e:
+            raise BaseException(f"Could not connect to controller at {self.__address}", e)
     
     # Disconnects the web socket connection
     def disconnect(self):
         try:
             self.__ws.close()
             self.__wsThread.join()
-        except:
-            raise BaseException("Error encountered while disconnecting from controller at " + self.__address)
+        except Exception as e:
+            raise BaseException(f"Error encountered while disconnecting from controller at {self.__address}", e)
 
     #Attempts to connect to a controller at the given address and retrieve data
     def connectAndGetData(self):

--- a/jellyfishlightspy/jellyfishmain.py
+++ b/jellyfishlightspy/jellyfishmain.py
@@ -42,13 +42,11 @@ class PatternName:
 #TODO: add a way to get the current pattern (runPattern)
 #TODO: add use of prebuilt pattern types
 class JellyFishController:
-    zones: Dict = {}
-    patternFiles: List[PatternName] = []
-    __ws = websocket.WebSocket()
-    __address: str
-    __printJSON: bool
 
     def __init__(self, address: str, printJSON: bool = False):
+        self.zones: Dict = {}
+        self.patternFiles: List[PatternName] = []
+        self.__ws = websocket.WebSocket()
         self.__address = address
         self.__printJSON = printJSON
     

--- a/readme.md
+++ b/readme.md
@@ -8,12 +8,14 @@ To install:
 
 **Current capabalilities**: 
 - Connects to a local JellyFish Lighting controller over websocket
-- Retrieve and store the following data:
+- Retrieves and stores the following data:
     - Zones
     - Pattern Files
-- Turn on and off controller lights
-- Play a pattern
-- Set any lights you want
+    - Active Run Pattern for a Zone
+- Turns on and off controller lights
+- Plays a pattern
+- Sets lights to a solid color with brightness control
+- Set any individual lights you want
 
 **Example**:
 ```python
@@ -21,22 +23,29 @@ from jellyfishlightspy import *
 
 controllerIP = "192.168.0.245"
 
-#We set the printJSON parameter to true to see the JSON sent to and recieved from the controller
+# We set the printJSON parameter to true to see the JSON sent to and recieved from the controller
 jfc = JellyFishController(controllerIP, True)
 jfc.connectAndGetData()
 jfc.turnOff()
 
 lights = LightString()
-#add red light
+# Add red light
 lights.add(Light(255, 0, 0))
-#add green light
+# Add green light
 lights.add(Light(0, 255, 0))
-#add blue light
+# Add blue light
 lights.add(Light(0, 0, 255))
 
-#Currently all commands that could turn on the lights themselves
-#  have an optional zones parameter. If not filled the api wrapper
-#  will fill it with all the zones it got from the controller
+# Currently all commands that could turn on the lights themselves
+# have an optional zones parameter. If not filled the api wrapper
+# will fill it with all the zones it got from the controller
 jfc.sendLightString(lights, ["Zone"])
 
+# Play a pre-saved pattern on all zones
+jfc.playPattern('Special Effects/Red Waves')
+rpd = jfc.getRunPattern("Zone")
+print(f"Zones is {'on' if rpd.state else 'off'} (pattern: '{rpd.file}')")
+
+# Set all zones to a solid color (white @ 100% brightness in this case)
+jfc.sendColor((255, 255, 255), 100)
 ```

--- a/readme.md
+++ b/readme.md
@@ -43,8 +43,11 @@ jfc.sendLightString(lights, ["Zone"])
 
 # Play a pre-saved pattern on all zones
 jfc.playPattern('Special Effects/Red Waves')
-rpd = jfc.getRunPattern("Zone")
-print(f"Zones is {'on' if rpd.state else 'off'} (pattern: '{rpd.file}')")
+
+# Retrieve current run pattern data for all zones
+rpd = jfc.getRunPatterns()
+for zone in rpd:
+    print(f"Zone '{zone}' is {'on' if rpd[zone].state else 'off'} (pattern: '{rpd[zone].file}')")
 
 # Set all zones to a solid color (white @ 100% brightness in this case)
 jfc.sendColor((255, 255, 255), 100)


### PR DESCRIPTION
Following up on PR #4, this is a new way to listen for data updates coming over the websocket that eliminates any concern about multiple responses per request. I've also observed that the controller will broadcast certain responses to **all active websocket connections** (not just to the requesting connection), so this enables multiple active connections to work independently without any concern of a response to a request from one connection impacting another connection. No timeouts or race conditions with this approach.

I've tested this with two threads, each fetching data and performing actions without any issue. Happy to iterate on these changes as needed.