### PR TITLE
Fix compatibility with JellyFish firmware 4.5.10

### DIFF
--- a/jellyfishlightspy/model.py
+++ b/jellyfishlightspy/model.py
@@ -73,12 +73,22 @@ class PatternConfig(ModelBase):
 
 
 class ZoneState(ModelBase):
-    def __init__(self, state: int, zoneName: List[str], file: Optional[str]=None, id: Optional[str]=None, data: Optional[PatternConfig]=None):
+    def __init__(
+        self,
+        state: int,
+        zoneName: List[str],
+        file: Optional[str]=None,
+        id: Optional[str]=None,
+        data: Optional[PatternConfig]=None,
+        activatedBy: Optional[str]=None,
+        **kwargs
+    ):
         self.state = state
         self.zoneName = zoneName
         self.file = file
         self.id = id
         self.data = data
+        self.activatedBy = activatedBy
 
     @property
     def is_on(self) -> bool:

--- a/jellyfishlightspy/requests.py
+++ b/jellyfishlightspy/requests.py
@@ -92,10 +92,23 @@ class SetZoneConfigRequest(SetRequest):
 
 
 class SetZoneStateRequest(SetRequest):
-    def __init__(self, state: int, zoneName: List[str], file: str="", id: str="", data: Optional[PatternConfig]=None):
+    def __init__(
+        self,
+        state: int,
+        zoneName: List[str],
+        file: str = "",
+        id: str = "",
+        data: Optional[PatternConfig] = None,
+    ):
         super().__init__()
-        self.runPattern = ZoneState(state=state, zoneName=zoneName, file=file, id=id, data=data)
-
+        self.runPattern = ZoneState(
+            state=state,
+            zoneName=zoneName,
+            file=file,
+            id=id,
+            data=data,
+            activatedBy="network_command",
+        )
 
 class SetPatternConfigRequest(SetRequest):
     def __init__(self, pattern: Pattern, jsonData: PatternConfig):


### PR DESCRIPTION
## Fix compatibility with JellyFish firmware 4.5.10

### Background

After upgrading a JellyFish controller to firmware 4.5.10, the library was no longer able to deserialize zone state updates received over the websocket connection.

The controller now includes an additional `activatedBy` field in `runPattern` / `ZoneState` payloads. Because `ZoneState` did not accept this field, all state updates failed with:

```
TypeError: ZoneState.__init__() got an unexpected keyword argument 'activatedBy'
```

In addition, controller commands such as `turn_on()`, `turn_off()`, and `apply_pattern()` were ignored by the controller unless `activatedBy="network_command"` was included in outbound `runPattern` payloads.

### Changes

#### ZoneState compatibility

* Add optional `activatedBy` parameter to `ZoneState`
* Store the value on the model for debugging/future use
* Add `**kwargs` support so future firmware additions do not break deserialization

#### Outbound command compatibility

* Include `activatedBy="network_command"` when creating `SetZoneStateRequest` payloads

### Compatibility

These changes are backwards compatible:

* Older firmware does not send `activatedBy`
* Older firmware should safely ignore the additional outbound field
* Unknown future fields will no longer cause deserialization failures

### Validation

Verified against JellyFish controller firmware:

```
4.5.10
```

The following functionality was confirmed working after the changes:

* get_zone_configs()
* get_zone_states()
* turn_on()
* turn_off()
* apply_pattern()
* Home Assistant state updates via websocket
