### PR TITLE
Support new firmware pattern settings in PatternConfig

### DIFF
--- a/jellyfishlightspy/helpers.py
+++ b/jellyfishlightspy/helpers.py
@@ -108,7 +108,7 @@ def _object_hook(data):
     # Instantiate the appropriate objects (vs. plain dicts)
     if "ver" in data:
         return FirmwareVersion(**data)
-    if "speed" in data:
+    if {"speed", "brightness", "effect"}.issubset(data):
         return RunConfig(**data)
     if "colors" in data:
         return PatternConfig(**data)

--- a/jellyfishlightspy/model.py
+++ b/jellyfishlightspy/model.py
@@ -56,7 +56,25 @@ class Pattern(ModelBase):
 
 
 class PatternConfig(ModelBase):
-    def __init__(self, type: str, colors: List[int], runData: RunConfig=None, direction: str="Center", spaceBetweenPixels: int=2, numOfLeds: int=1, skip: int=2, effectBetweenPixels: str="No Color Transform", colorPos: List[int]=None, cursor: int=-1, ledOnPos: Dict[str, int]=None, soffitZone: str="") -> None:
+    def __init__(
+        self,
+        type: str,
+        colors: List[int],
+        runData: RunConfig = None,
+        direction: str = "Center",
+        spaceBetweenPixels: int = 2,
+        numOfLeds: int = 1,
+        skip: int = 2,
+        effectBetweenPixels: str = "No Color Transform",
+        colorPos: List[int] = None,
+        cursor: int = -1,
+        ledOnPos: Dict[str, int] = None,
+        soffitZone: str = "",
+        blingSettings: Optional[dict] = None,
+        shimmerSettings: Optional[dict] = None,
+        rippleSettings: Optional[dict] = None,
+        **kwargs,
+    ) -> None:
         self.type = type
         self.colors = colors
         self.runData = runData
@@ -70,6 +88,10 @@ class PatternConfig(ModelBase):
         # These attributes appear to be optional and are only seen on soffit patterns
         self.ledOnPos = ledOnPos or {}
         self.soffitZone = soffitZone
+        # These attributes appear to be from a newer version of the firmware
+        self.blingSettings = blingSettings
+        self.shimmerSettings = shimmerSettings
+        self.rippleSettings = rippleSettings
 
 
 class ZoneState(ModelBase):


### PR DESCRIPTION
Newer JellyFish controller firmware includes effect-specific settings objects
inside pattern data, such as `blingSettings`, `shimmerSettings`, and
`rippleSettings`.

These currently cause websocket parsing to fail with errors such as:

`TypeError: PatternConfig.__init__() got an unexpected keyword argument 'blingSettings'`

This change adds support for the known settings objects and allows unknown
future fields through `**kwargs`, preventing new controller fields from
breaking zone-state updates.

This change is backwards compatible with earlier firmware and should prevent errors if future firmware adds more settings objects. 